### PR TITLE
UPDATE:Move MCP to base_agent.py, and make the MCP service configurable through pywen_config.json

### DIFF
--- a/pywen/cli.py
+++ b/pywen/cli.py
@@ -257,6 +257,7 @@ async def interactive_mode_streaming(agent: QwenAgent, console: CLIConsole, sess
         except Exception as e:
             console.print(f"Error: {e}", "red")
             in_task_execution = False
+    await current_agent.aclose()
 
 
 async def execute_streaming_with_cancellation(agent, user_input, console, cancel_event):


### PR DESCRIPTION
1. 在pywen_cofnfig.json中添加了mcp相关配置，并允许在extra字段添加自定义配置
2. 移动mcp启动相关内容到base_agent.py 基类中，各agent不需要单独编写。
3. 修复了部分退出时mcp无法正常关闭导致的报错

其他需要重点关注的问题：
1. config增加配置困难
2. 开发者实现自己的agent时，需要显示调用setup_tools方法。由于mcp需要启动服务，消耗资源，且是个异步方法，不推荐放在__init__()中，放在__aenter__（）中更好，但是又因为我们目前agent还没有抽象好，不方便使用`with agent():`的方式运行，现在依然需要开发者手动调用setup_tools方法。无法规范使用`with agent():`的方式，也导致清理mcp资源无法放在`__aexit()__`中自动执行，这也是导致退出时mcp资源未正常清理报错的原因。 后续等功能稳定需要重新梳理。
3. 由于我们纯python环境，但是playwright mcp是nodejs服务，pyproject.toml无法管理playwright依赖。实际也不需要用户手动安装，执行npx @playwright/mcp@latest时会自动下载并缓存，但是需要一定网络环境，用户可能依然无法安装。需要适当提示说明。