### PR TITLE
FEAT: Add MCP configuration to the default generated config file, but keep it disabled by default.

### DIFF
--- a/pywen/config/loader.py
+++ b/pywen/config/loader.py
@@ -234,6 +234,21 @@ def create_default_config(output_path: str = None) -> None:
                 "parallel_tool_calls": True,
                 "max_retries": 3
             }
+        },
+        "mcp": {
+            "enabled": True,
+            "isolated": True,
+            "servers": [
+                {
+                  "name": "playwright",
+                  "command": "npx",
+                  "args": ["@playwright/mcp@latest"],
+                  "enabled": False,
+                  "include": ["browser_*"],
+                  "save_images_dir": "./outputs/playwright",
+                  "isolated": True 
+                }
+            ]
         }
     }
 

--- a/pywen/ui/config_wizard.py
+++ b/pywen/ui/config_wizard.py
@@ -365,6 +365,21 @@ class ConfigWizard:
                     "parallel_tool_calls": True,
                     "max_retries": 3
                 }
+            },
+            "mcp": {
+                "enabled": True,
+                "isolated": True,
+                "servers": [
+                    {
+                      "name": "playwright",
+                      "command": "npx",
+                      "args": ["@playwright/mcp@latest"],
+                      "enabled": False,
+                      "include": ["browser_*"],
+                      "save_images_dir": "./outputs/playwright",
+                      "isolated": True 
+                    }
+                ]
             }
         }
 


### PR DESCRIPTION
添加默认的mcp配置，默认不开启，用户手动开启后才能使用。