### PR TITLE
FIX:MCP 

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ For detailed information about all available tools and their capabilities, see [
 
 ## 🔌 MCP (Model Context Protocol) Integration
 
-Pywen also supports **MCP (Model Context Protocol)** to connect external tools and services such as browsers.
+Pywen also supports **MCP (Model Context Protocol)** to connect external tools and services such as playwright.
 
 ### Enabling MCP
 1. Open your configuration file:
@@ -270,7 +270,7 @@ If your device does not have a browser installed, install browser for Playwright
 npx playwright install --with-deps
 ```
 
-After enabling MCP and installing the required browser, Pywen will be able to call the `browser_use` MCP server for tasks like browser automation, screenshot capture, and web interaction.
+After enabling MCP and installing the required browser, Pywen will be able to call the `playwright` MCP server for tasks like browser automation, screenshot capture, and web interaction.
 
 ## 📊 Trajectory Recording
 

--- a/README.md
+++ b/README.md
@@ -235,27 +235,39 @@ Pywen also supports **MCP (Model Context Protocol)** to connect external tools a
 2. Locate the `mcp` section and enable it:
    ```json
    "mcp": {
-     "enabled": true,
-     "isolated": true,
-     "servers": [
-       {
-         "name": "browser_use",
-         "command": "browser-use",
-         "args": ["--mcp"],
-         "enabled": true,
-         "include": ["browser_*"],
-         "save_images_dir": "./outputs/playwright",
-         "isolated": false
-       }
-     ]
+       "enabled": true,
+           "isolated": true,
+           "servers": [
+           {
+               "name": "playwright",
+               "command": "npx",
+               "args": [
+                   "@playwright/mcp@latest"
+               ],
+               "enabled": true,
+               "include": [
+                   "browser_*"
+               ],
+               "save_images_dir": "./outputs/playwright",
+               "isolated": false
+           }
+           ]
    }
-   ```
 
-### Browser Dependency
-If your device does not have a browser installed, install Chromium for Playwright with:
+   ```
+### Node.js 
+Ensure that you have Node.js installed. You can verify it with the following command:
 
 ```bash
-uvx playwright install chromium --with-deps 
+node -v
+```
+If you don’t have it installed, please follow the [Node.js installation guide](https://nodejs.org/).
+
+### Browser Dependency
+If your device does not have a browser installed, install browser for Playwright with:
+
+```bash
+npx playwright install --with-deps
 ```
 
 After enabling MCP and installing the required browser, Pywen will be able to call the `browser_use` MCP server for tasks like browser automation, screenshot capture, and web interaction.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Pywen also supports **MCP (Model Context Protocol)** to connect external tools a
                    "browser_*"
                ],
                "save_images_dir": "./outputs/playwright",
-               "isolated": false
+               "isolated": true 
            }
            ]
    }

--- a/README_ch.md
+++ b/README_ch.md
@@ -223,25 +223,34 @@ Pywen 还支持 **MCP（Model Context Protocol）**，可用于连接外部工�
      "isolated": true,
      "servers": [
        {
-         "name": "browser_use",
-         "command": "browser-use",
-         "args": ["--mcp"],
+         "name": "playwright",
+         "command": "npx",
+         "args": ["@playwright/mcp@latest"],
          "enabled": true,
          "include": ["browser_*"],
          "save_images_dir": "./outputs/playwright",
-         "isolated": false
+         "isolated": true 
        }
      ]
    }
    ```
+### 安装 Node.js 环境
+
+确保你的设备已安装 Node.js。你可以通过以下命令验证：
+```bash
+node -v 
+```
+如果没有安装，请按照 [Node.js 安装指南](https://nodejs.org)安装
 
 ### 浏览器依赖
-如果您的设备没有安装浏览器，可以使用以下命令安装 Chromium（供 Playwright 使用）：
 
+如果你的设备没有安装浏览器，可以使用以下命令为 Playwright 安装浏览器：
 ```bash
-uvx playwright install chromium --with-deps
+npx playwright install --with-deps
 ```
-启用 MCP 并安装所需浏览器后，Pywen 就可以调用 `browser_use` MCP 服务端来执行浏览器自动化、截图和网页交互等任务。
+这将安装 Chromium 浏览器并解决所有 Playwright 所需的系统依赖。
+启用 MCP 并安装所需浏览器后，Pywen 将能够调用 playwright MCP 服务端来执行浏览器自动化、截图捕获以及网页交互等任务。
+
 
 ## 📊 轨迹记录
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 readme = "README.md"
-requires-python = ">=3.11, <3.13"
+requires-python = ">=3.10, <3.13"
 dependencies = [
     "openai>=1.86.0",
     "anthropic>=0.54.0",
@@ -37,7 +37,6 @@ dependencies = [
     "aiohttp>=3.12.13",
     "loguru>=0.7.3",
     "mcp>=1.13.0",
-    "browser-use==0.6.3",
 ]
 
 [project.scripts]

--- a/pywen/config/loader.py
+++ b/pywen/config/loader.py
@@ -82,13 +82,13 @@ def load_config_from_file(config_path: str = None) -> Config:
             "isolated": True,
             "servers": [
                 {
-                  "name": "browser_use",
-                  "command": "browser-use",
-                  "args": ["--mcp"],
+                  "name": "playwright",
+                  "command": "npx",
+                  "args": ["@playwright/mcp@latest"],
                   "enabled": False,
                   "include": ["browser_*"],
                   "save_images_dir": "./outputs/playwright",
-                  "isolated": False 
+                  "isolated": True 
                 }
             ]
         }
@@ -295,9 +295,9 @@ def create_default_config(output_path: str = None) -> None:
             "isolated": True,
             "servers": [
                 {
-                  "name": "browser_use",
-                  "command": "browser-use",
-                  "args": ["--mcp"],
+                  "name": "playwright",
+                  "command": "npx",
+                  "args": ["@playwright/mcp@latest"],
                   "enabled": False,
                   "include": ["browser_*"],
                   "save_images_dir": "./outputs/playwright",

--- a/pywen/ui/config_wizard.py
+++ b/pywen/ui/config_wizard.py
@@ -371,13 +371,13 @@ class ConfigWizard:
                 "isolated": True,
                 "servers": [
                     {
-                      "name": "browser_use",
-                      "command": "browser-use",
-                      "args": ["--mcp"],
+                      "name": "playwright",
+                      "command": "npx",
+                      "args": ["@playwright/mcp@latest"],
                       "enabled": False,
                       "include": ["browser_*"],
                       "save_images_dir": "./outputs/playwright",
-                      "isolated": False 
+                      "isolated": True
                     }
                 ]
             }


### PR DESCRIPTION
mcp重新使用playwright，更新readme文件，提示用户安装node以及保证浏览器环境。

注意：
1. main分支需要同步更新，当前main分支未更新pyproject.tmol文件，无法使用。
2. 需要同步修改版本号
