### PR TITLE
fix(grep): 修复无效正则表达式被误报为无匹配的问题

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pywen"
-version = "2.0.0"
+version = "2.0.0a3"
 description = "LLM-based agent for general purpose tasks"
 authors = [
   { name ="PAMPAS-Lab" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "mcp>=1.13.0",
     "pytest>=8.0.0",
     "pyyaml>=6.0",
+    "pytest-asyncio>=1.4.0",
 ]
 
 [project.optional-dependencies]

--- a/pywen/tools/grep_tool.py
+++ b/pywen/tools/grep_tool.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, Mapping
+from typing import Any, Mapping, Pattern
 from .base_tool import BaseTool, ToolCallResult
 from pywen.tools.tool_manager import register_tool
 
@@ -63,22 +63,36 @@ class GrepTool(BaseTool):
             return ToolCallResult(call_id="", error="No path provided")
         
         try:
+            compiled_pattern = None
+            if use_regex:
+                flags = 0 if case_sensitive else re.IGNORECASE
+                try:
+                    compiled_pattern = re.compile(pattern, flags)
+                except re.error as e:
+                    return ToolCallResult(call_id="", error=f"Invalid regex pattern: {str(e)}")
+
             results = []
             if os.path.isfile(path):
-                matches = self._search_in_file(path, pattern, case_sensitive, use_regex)
+                matches = self._search_in_file(
+                    path, pattern, case_sensitive, compiled_pattern
+                )
                 results.extend(matches)
             elif os.path.isdir(path):
                 if recursive:
                     for root, dirs, files in os.walk(path):
                         for file in files:
                             file_path = os.path.join(root, file)
-                            matches = self._search_in_file(file_path, pattern, case_sensitive, use_regex)
+                            matches = self._search_in_file(
+                                file_path, pattern, case_sensitive, compiled_pattern
+                            )
                             results.extend(matches)
                 else:
                     for item in os.listdir(path):
                         item_path = os.path.join(path, item)
                         if os.path.isfile(item_path):
-                            matches = self._search_in_file(item_path, pattern, case_sensitive, use_regex)
+                            matches = self._search_in_file(
+                                item_path, pattern, case_sensitive, compiled_pattern
+                            )
                             results.extend(matches)
             if not results:
                 return ToolCallResult(call_id="", result="No matches found")
@@ -88,13 +102,19 @@ class GrepTool(BaseTool):
         except Exception as e:
             return ToolCallResult(call_id="", error=f"Error searching: {str(e)}")
     
-    def _search_in_file(self, file_path: str, pattern: str, case_sensitive: bool, use_regex: bool) -> list:
+    def _search_in_file(
+        self,
+        file_path: str,
+        pattern: str,
+        case_sensitive: bool,
+        compiled_pattern: Pattern[str] | None = None,
+    ) -> list:
         """Search for pattern in a single file."""
         results = []
         try:
             with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                 for line_num, line in enumerate(f, 1):
-                    if self._match_line(line, pattern, case_sensitive, use_regex):
+                    if self._match_line(line, pattern, case_sensitive, compiled_pattern):
                         results.append(f"{file_path}:{line_num}:{line.strip()}")
         except Exception:
             # Skip files that can't be read
@@ -102,20 +122,19 @@ class GrepTool(BaseTool):
         
         return results
     
-    def _match_line(self, line: str, pattern: str, case_sensitive: bool, use_regex: bool) -> bool:
-        if use_regex:
-            flags = 0 if case_sensitive else re.IGNORECASE
-            try:
-                return bool(re.search(pattern, line, flags))
-            except re.error:
-                use_regex = False
-        else:
-            if case_sensitive:
-                return pattern in line
-            else:
-                return pattern.lower() in line.lower()
-        
-        return False
+    def _match_line(
+        self,
+        line: str,
+        pattern: str,
+        case_sensitive: bool,
+        compiled_pattern: Pattern[str] | None = None,
+    ) -> bool:
+        if compiled_pattern is not None:
+            return bool(compiled_pattern.search(line))
+
+        if case_sensitive:
+            return pattern in line
+        return pattern.lower() in line.lower()
 
     def build(self, provider:str = "", func_type: str = "") -> Mapping[str, Any]:
         if provider.lower() == "claude" or provider.lower() == "anthropic":

--- a/tests/test_grep_tool.py
+++ b/tests/test_grep_tool.py
@@ -1,0 +1,48 @@
+import pytest
+
+from pywen.tools.grep_tool import GrepTool
+
+
+@pytest.mark.asyncio
+async def test_grep_reports_invalid_regex(tmp_path):
+    test_file = tmp_path / "sample.txt"
+    test_file.write_text("hello\n", encoding="utf-8")
+
+    result = await GrepTool().execute(
+        pattern="[",
+        path=str(test_file),
+        regex=True,
+    )
+
+    assert result.error is not None
+    assert "Invalid regex pattern" in result.error
+
+
+@pytest.mark.asyncio
+async def test_grep_regex_matches_file_content(tmp_path):
+    test_file = tmp_path / "sample.txt"
+    test_file.write_text("alpha\nbeta-123\n", encoding="utf-8")
+
+    result = await GrepTool().execute(
+        pattern=r"beta-\d+",
+        path=str(test_file),
+        regex=True,
+    )
+
+    assert result.error is None
+    assert f"{test_file}:2:beta-123" in result.result
+
+
+@pytest.mark.asyncio
+async def test_grep_plain_text_case_insensitive(tmp_path):
+    test_file = tmp_path / "sample.txt"
+    test_file.write_text("Pywen Agent\n", encoding="utf-8")
+
+    result = await GrepTool().execute(
+        pattern="pywen",
+        path=str(test_file),
+        case_sensitive=False,
+    )
+
+    assert result.error is None
+    assert f"{test_file}:1:Pywen Agent" in result.result

--- a/uv.lock
+++ b/uv.lock
@@ -3760,7 +3760,7 @@ wheels = [
 
 [[package]]
 name = "pywen"
-version = "2.0.0"
+version = "2.0.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },

--- a/uv.lock
+++ b/uv.lock
@@ -159,6 +159,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -308,7 +317,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -3697,6 +3706,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3737,7 +3760,7 @@ wheels = [
 
 [[package]]
 name = "pywen"
-version = "2.0.0a3"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
@@ -3753,6 +3776,7 @@ dependencies = [
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -3789,6 +3813,7 @@ requires-dist = [
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.4.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0.0" },


### PR DESCRIPTION
## Summary
- 修复 `GrepTool` 在 `regex=True` 且正则表达式无效时返回 `No matches found` 的问题。
- 在搜索前预编译正则表达式，并在扫描文件时复用编译结果。
- 保持普通文本搜索和大小写不敏感搜索行为不变。

## Tests
- Added tests for invalid regex handling, regex matching, and case-insensitive plain text matching.
- Verified syntax with `py_compile`.